### PR TITLE
add DEVモード追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -4,10 +4,22 @@ import traceback
 
 DISCORD_TOKEN = settings.DISCORD_TOKEN
 COMMAND_PREFIX = settings.COMMAND_PREFIX
+RUN_MODE = settings.RUN_MODE
 
+# cogsフォルダのみ追加
 INITIAL_EXETENDIONS = [
 
 ]
+
+# cogs_devフォルダのみ追加
+DEV_COGS = [
+
+]
+
+# RUN_MODEがDEVならcogs_devの中身も読む
+if RUN_MODE == "DEV":
+    INITIAL_EXETENDIONS.append(DEV_COGS)
+
 
 
 class MyBot(commands.Bot):

--- a/src/settings.py
+++ b/src/settings.py
@@ -11,3 +11,4 @@ load_dotenv(dotenv_path)
 
 DISCORD_TOKEN = os.environ.get("DISCORD_TOKEN")
 COMMAND_PREFIX = os.environ.get("COMMAND_PREFIX")
+RUN_MODE = os.environ.get("RUN_MODE")


### PR DESCRIPTION
開発環境でのみ必要なコマンド類を入れておくためにDEVモードを追加しました

通常のBotで動作して欲しいものはcogsフォルダに開発環境でのみ使用するコマンドをcogs_devの中に入れる
（フォルダ名は名前順にした際のことを考えcogsが先です)

DEVモードにする場合はRUN_MODE="DEV"を追記してください